### PR TITLE
Fix menu button on purecss.io

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -33,7 +33,7 @@
     }
     
     function handleEvent(e) {
-        if (e.target.id === menuLink.id) {
+        if (menuLink.contains(e.target)) {
             return toggleAll(e);
         }
         


### PR DESCRIPTION
*Caution: the proposed fix is untested*

On purecss.io, clicking the menu button requires clicking exactly on the element with ID "menuLink".  However, the button contains three span elements (for the hamburger button), and if the click lands within one of those elements, the menu does not open up as expected.

I changed the code to toggle the menu if the click is received on menuLink or any descendant of menuLink.